### PR TITLE
Add template properties for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,5 +62,4 @@ target
 *.backup
 
 /build/
-*.properties
 .DS_Store

--- a/src/test/resources/test-local.properties
+++ b/src/test/resources/test-local.properties
@@ -1,0 +1,69 @@
+# Base Properties For This Environment
+cuc.collect.username = admin
+cuc.collect.password = secret
+
+# ActionExporter properties
+cuc.collect.actionexp.host = localhost
+cuc.collect.actionexp.port = 8141
+cuc.collect.actionexp.username = actionexporter
+cuc.collect.actionexp.password = ctp
+cuc.collect.actionexp.print.file = Documents/sftp/
+cuc.collect.actionexp.ftl.location = ./src/test/resources/actionexportersvc/
+
+# Action Service Properties
+cuc.collect.actionsvc.host = localhost
+cuc.collect.actionsvc.port = 8151
+
+# Case Service Properties
+cuc.collect.casesvc.host = localhost
+cuc.collect.casesvc.port = 8171
+
+# Collection Exercise Service Properties
+cuc.collect.collectionexercisesvc.host = localhost
+cuc.collect.collectionexercisesvc.port = 8145
+
+# Database Tool Properties
+cuc.collect.dbtool.host = localhost
+cuc.collect.dbtool.port = 9000
+
+# IAC Service properties
+cuc.collect.iacsvc.host = localhost
+cuc.collect.iacsvc.port = 8121
+cuc.collect.iacsvc.username = admin
+cuc.collect.iacsvc.password = secret
+
+# DRS Gateway properties
+cuc.collect.drsgateway.host = localhost
+cuc.collect.drsgateway.username = gateway
+cuc.collect.drsgateway.password = ctp
+
+# Sample Service properties
+cuc.collect.samplesvc.host = localhost
+cuc.collect.samplesvc.port = 8125
+cuc.collect.samplesvc.xsd.location = samplesvc/xsd/inbound/
+cuc.collect.samplesvc.xml.location = ./src/test/resources/samplesvc/
+cuc.collect.samplesvc.sftp.survey = ./Documents/sftp/Sample-Files/%s/
+cuc.collect.samplesvc.csv.location = src/test/resources/samplesvc/
+
+# SDX Gateway properties
+cuc.collect.sdxgateway.port = 8191
+cuc.collect.sdxgateway.host = localhost
+cuc.collect.sdxgateway.username = gateway
+cuc.collect.sdxgateway.password = ctp
+
+# SFTP properties
+cuc.sftp.server = localhost
+cuc.sftp.port = 122
+cuc.sftp.samplesvc.username = centos
+cuc.sftp.samplesvc.password = JLibV2&XD,
+cuc.sftp.actionexp.username = centos
+cuc.sftp.actionexp.password = JLibV2&XD,
+
+# Survey Service properties
+cuc.collect.surveysvc.host = localhost
+cuc.collect.surveysvc.port = 8080
+
+# UI properties
+cuc.collect.ui.chrome.driver.location = /usr/local/bin/chromedriver
+cuc.collect.ui.host = localhost
+cuc.collect.ui.port = 9515

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,15 @@
+# General Properties
+cuc.protocol = http
+# Database Tool Properties
+cuc.collect.dbtool.port = 9000
+# DRS Gateway Properties
+cuc.collect.drsgateway.port = 8131
+# Sample Service Properties
+cuc.collect.samplesvc.valid.filename = %s-survey-full%s.csv
+cuc.collect.samplesvc.invalid.filename = %s-survey-invalid.xml
+cuc.collect.samplesvc.min.filename = %s-survey-min.xml
+# UI Properties
+integration.test.username = integration.tester@ons.gov.uk
+integration.test.password = IntTester
+# Sql File location
+cuc.sql.location = ./src/test/resources/database/


### PR DESCRIPTION
Creating a template test.properties and test-local.properties files to
enable tests to run locally. The properties should allow tests to be
easily ran using docker services or standalone java processes.

No sensitive data exists in the properties files.