### PR TITLE
Fixing smoke test by seeding actionrules for single reminders instead…

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/response/common/steps/PostgresSteps.java
+++ b/src/test/java/uk/gov/ons/ctp/response/common/steps/PostgresSteps.java
@@ -126,6 +126,16 @@ public class PostgresSteps {
   }
 
   /**
+   * Confirm seeding of action service postgres DB
+   *
+   * @throws Throwable pass the exception
+   */
+  @Then("^the actionsvc database has been seeded$")
+  public void the_actionsvc_database_has_been_seeded() throws Throwable {
+    checkRecordsInDBEqual("action.actionrule", 3);
+  }
+  
+  /**
    * Confirm clean of action exporter postgres DB
    *
    * @throws Throwable pass the exception

--- a/src/test/resources/database/actionsvc/actionreset.sql
+++ b/src/test/resources/database/actionsvc/actionreset.sql
@@ -4,6 +4,7 @@ TRUNCATE action.action CASCADE;
 TRUNCATE action.actionplanjob CASCADE;
 TRUNCATE action.case CASCADE;
 TRUNCATE action.messagelog CASCADE;
+TRUNCATE action.actionrule CASCADE;
 
 ALTER SEQUENCE action.actionpkseq RESTART WITH 1;
 ALTER SEQUENCE action.actionplanjobseq RESTART WITH 1;

--- a/src/test/resources/database/actionsvc/actionseed.sql
+++ b/src/test/resources/database/actionsvc/actionseed.sql
@@ -1,0 +1,10 @@
+SET SCHEMA 'action';
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (1, 1, 1, 'BSNOT+0', 'Enrolment Invitation Letter(+0 days)', 0, 3);
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (2, 1, 2, 'BSREM+45', 'Enrolment Reminder Letter(+45 days)', 45, 3);
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (4, 2, 3, 'BSSNE+45', 'Survey Reminder Notification(+45 days)', 45, 3);

--- a/src/test/resources/uk/gov/ons/ctp/smoke/smoke.feature
+++ b/src/test/resources/uk/gov/ons/ctp/smoke/smoke.feature
@@ -6,6 +6,7 @@
 #                                        pre test clean of collection exercise service
 #                                        pre test clean of case service
 #                                        pre test clean of action service
+#										pre test seed of action service
 #                                        pre test clean of action exporter
 #                                        test business sample load
 #                                        test business sample load validation failure
@@ -44,6 +45,10 @@ Feature: Smoke Test
   Scenario: Reset action service database to pre test condition
     When for the "actionsvc" run the "actionreset.sql" postgres DB script
     Then the actionsvc database has been reset
+
+  Scenario: Seed action service database to pre test condition
+    When for the "actionsvc" run the "actionseed.sql" postgres DB script
+    Then the actionsvc database has been seeded
 
   Scenario: Reset actionexporter database to pre test condition
     When for the "actionexporter" run the "actionexporterreset.sql" postgres DB script


### PR DESCRIPTION
… of default multiple reminders

smoke test run after after Friday 24 November began failing due to action.actionrule(s) existing as reference/standing data. The +73 offset rules that trigger the 2nd set of reminders came into effect on that date. This causes 1497 actions to be created and processed instead of the 497 that were previously being created prior to that date. The assertions that are checking the number of actions being created then started failing as there were 500 more actions than expected.

This pull request is a short-medium term workaround to the failing smoke tests which truncates the actionrule table (of the 5 rules) and inserts only the 3 rules needed to meet the existing assertions.