### PR TITLE
Fixing sendEnrolment and UI Tests

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/response/common/steps/PostgresSteps.java
+++ b/src/test/java/uk/gov/ons/ctp/response/common/steps/PostgresSteps.java
@@ -360,4 +360,34 @@ public class PostgresSteps {
 
     return time.toString();
   }
+  
+  /**
+   * Confirm seeding of notification event within the action service postgres DB
+   *
+   * @throws Throwable pass the exception
+   */
+  @Then("^the notification event has been seeded$")
+  public void the_notification_event_has_been_seeded() throws Throwable {
+    checkRecordsInDBEqual("action.actionrule", 1);
+  }
+
+  /**
+   * Confirm seeding of first reminder events within the action service postgres DB
+   *
+   * @throws Throwable pass the exception
+   */
+  @Then("^the first reminder events have been seeded$")
+  public void the_first_reminder_events_have_been_seeded() throws Throwable {
+    checkRecordsInDBEqual("action.actionrule", 3);
+  }
+  
+  /**
+   * Confirm seeding of second reminder events within the action service postgres DB
+   *
+   * @throws Throwable pass the exception
+   */
+  @Then("^the second reminder events have been seeded$")
+  public void the_second_reminder_events_have_been_seeded() throws Throwable {
+    checkRecordsInDBEqual("action.actionrule", 5);
+  }
 }

--- a/src/test/resources/database/actionsvc/firstreminderactionseed.sql
+++ b/src/test/resources/database/actionsvc/firstreminderactionseed.sql
@@ -1,0 +1,7 @@
+SET SCHEMA 'action';
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (2, 1, 2, 'BSREM+45', 'Enrolment Reminder Letter(+45 days)', 45, 3);
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (4, 2, 3, 'BSSNE+45', 'Survey Reminder Notification(+45 days)', 45, 3);

--- a/src/test/resources/database/actionsvc/notificationactionseed.sql
+++ b/src/test/resources/database/actionsvc/notificationactionseed.sql
@@ -1,0 +1,4 @@
+SET SCHEMA 'action';
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (1, 1, 1, 'BSNOT+0', 'Enrolment Invitation Letter(+0 days)', 0, 3);

--- a/src/test/resources/database/actionsvc/secondreminderactionseed.sql
+++ b/src/test/resources/database/actionsvc/secondreminderactionseed.sql
@@ -1,0 +1,7 @@
+SET SCHEMA 'action';
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (3, 1, 2, 'BSREM+45', 'Enrolment Reminder Letter(+45 days)', 45, 3);
+
+INSERT INTO action.actionrule (actionrulepk, actionplanfk, actiontypefk, name, description, daysoffset, priority)
+VALUES (5, 2, 3, 'BSSNE+45', 'Survey Reminder Notification(+45 days)', 45, 3);

--- a/src/test/resources/uk/gov/ons/ctp/journeys/send/enrolment/enrolmentLettersAndReminders.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/send/enrolment/enrolmentLettersAndReminders.feature
@@ -64,6 +64,10 @@ Feature: Tests the enrolment letter and reminder letters are sent
   Scenario: Reset action service database to pre test condition
     When for the "actionsvc" run the "actionreset.sql" postgres DB script
     Then the actionsvc database has been reset
+    
+  Scenario: Seed action service database for notification event
+    When for the "actionsvc" run the "notificationactionseed.sql" postgres DB script
+    Then the notification event has been seeded
 
 
   # Pre Test Action Exporter Environment Set Up -----
@@ -109,7 +113,7 @@ Feature: Tests the enrolment letter and reminder letters are sent
       | 1             | 1            | 1            | 497   |
     When after a delay of 90 seconds
     Then check "action.action" records in DB
-      | actionplanfk  | actionrulepk | actiontypefk | statefk   | total |
+      | actionplanfk  | actionrulefk | actiontypefk | statefk   | total |
       | 1             | 1            | 1            | COMPLETED | 497   |
     And check "casesvc.caseevent" records in DB equal 497 for "description = 'Enrolment Invitation Letter'"
 
@@ -154,13 +158,17 @@ Feature: Tests the enrolment letter and reminder letters are sent
 
   # Send Enrolment Reminder Letters (First) -----
 
+  Scenario: Seed action service database for first reminder events
+    When for the "actionsvc" run the "firstreminderactionseed.sql" postgres DB script
+    Then the first reminder events have been seeded
+  
   Scenario: Test action creation by post request to create actions for specified action plan (Journey steps: 4.1, 4.2, 4.3, 4.4, 4.5, 4.7)
     Given the case start date is adjusted to trigger action plan
       | actionplanfk  | actionrulepk | actiontypefk | total |
       | 1             | 2            | 2            | 497   |
     When after a delay of 90 seconds
     Then check "action.action" records in DB
-      | actionplanfk  | actionrulepk | actiontypefk | statefk   | total |
+      | actionplanfk  | actionrulefk | actiontypefk | statefk   | total |
       | 1             | 2            | 2            | COMPLETED | 497   |
     And check "casesvc.caseevent" records in DB equal 497 for "description = 'Enrolment Reminder Letter'"
 
@@ -203,6 +211,10 @@ Feature: Tests the enrolment letter and reminder letters are sent
 
 
   # Send Enrolment Reminder Letters (Second) -----
+  
+  Scenario: Seed action service database for second reminder events
+    When for the "actionsvc" run the "secondreminderactionseed.sql" postgres DB script
+    Then the second reminder events have been seeded
 
   Scenario: Test action creation by post request to create actions for specified action plan (Journey steps: 4.1, 4.2, 4.3, 4.4, 4.5, 4.7)
     Given the case start date is adjusted to trigger action plan
@@ -210,7 +222,7 @@ Feature: Tests the enrolment letter and reminder letters are sent
       | 1             | 3            | 2            | 497   |
     When after a delay of 90 seconds
     Then check "action.action" records in DB
-      | actionplanfk  | actionrulepk | actiontypefk | statefk   | total |
+      | actionplanfk  | actionrulefk | actiontypefk | statefk   | total |
       | 1             | 3            | 2            | COMPLETED | 497   |
     And check "casesvc.caseevent" records in DB equal 994 for "description = 'Enrolment Reminder Letter'"
 

--- a/src/test/resources/uk/gov/ons/ctp/ui/rm/ro/uiResponseOperation.feature
+++ b/src/test/resources/uk/gov/ons/ctp/ui/rm/ro/uiResponseOperation.feature
@@ -61,6 +61,10 @@ Feature: Tests for response operations UI
   Scenario: Reset action service database to pre test condition
     When for the "actionsvc" run the "actionreset.sql" postgres DB script
     Then the actionsvc database has been reset
+    
+  Scenario: Seed action service database for notification event
+    When for the "actionsvc" run the "notificationactionseed.sql" postgres DB script
+    Then the notification event has been seeded
 
 
   # Pre Test Action Exporter Environment Set Up -----
@@ -103,7 +107,7 @@ Feature: Tests for response operations UI
       | 1             | 1            | 1            | 497   |
     When after a delay of 90 seconds
     Then check "action.action" records in DB
-      | actionplanfk  | actionrulepk | actiontypefk | statefk   | total |
+      | actionplanfk  | actionrulefk | actiontypefk | statefk   | total |
       | 1             | 1            | 1            | COMPLETED | 497   |
     And check "casesvc.caseevent" records in DB equal 497 for "description = 'Enrolment Invitation Letter'"
 


### PR DESCRIPTION
Updated tests to seed in notification, first reminder and second
reminder action rule events separately before triggering the action
plan.