### PR TITLE
Fixing collection exercise execute

### DIFF
--- a/src/test/java/uk/gov/ons/ctp/response/collectionexercisesvc/steps/CollectionExerciseSvcSteps.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collectionexercisesvc/steps/CollectionExerciseSvcSteps.java
@@ -32,7 +32,6 @@ public class CollectionExerciseSvcSteps {
   /**
    * Test put request for /collectionexercises/{exerciseId}.
    *
-   * @param exerciseId exercise id
    * @throws Throwable pass the exception
    */
   @Given("^I retrieve From Sample DB the Sample Summary$")
@@ -60,15 +59,15 @@ public class CollectionExerciseSvcSteps {
   }
   
   /**
-   * Test put request for /collectionexercises/{exerciseId}.
+   * Test post request for /collectionexerciseexecution/{exerciseId}.
    *
    * @param exerciseId exercise id
    * @throws Throwable pass the exception
    */
-  @Given("^I make the PUT call to the collection exercise endpoint for exercise id \"(.*?)\"$")
-  public void i_make_the_PUT_call_to_the_collection_exercise_endpoint_for_exercise_id(String exerciseId)
+  @Given("^I make the POST call to the collection exercise execution endpoint for exercise id \"(.*?)\"$")
+  public void i_make_the_POST_call_to_the_collection_exercise_execution_endpoint_for_exercise_id(String exerciseId)
       throws Throwable {
-    responseAware.invokePutCollectionExerciseId(exerciseId);
+    responseAware.invokePostCollectionExerciseId(exerciseId);
   }
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/response/collectionexercisesvc/util/CollectionExerciseSvcResponseAware.java
+++ b/src/test/java/uk/gov/ons/ctp/response/collectionexercisesvc/util/CollectionExerciseSvcResponseAware.java
@@ -15,7 +15,7 @@ import uk.gov.ons.ctp.util.World;
  * Created by Stephen Goddard on 12/5/17.
  */
 public class CollectionExerciseSvcResponseAware {
-  private static final String PUT_EXERCISE_URL = "/collectionexercises/%s";
+  private static final String POST_EXERCISE_URL = "/collectionexerciseexecution/%s";
   private static final String GET_SURVEY_URL = "/collectionexercises/survey/%s";
   private static final String GET_EXERCISE_URL = "/collectionexercises/%s";
   private static final String PUT_SAMPLE_URL = "/collectionexercises/link/%s";
@@ -41,7 +41,7 @@ public class CollectionExerciseSvcResponseAware {
   /**
    *
    *
-   * @param samplesummaryId samplesummary Id
+   * @param sampleSummaryId samplesummary Id
    * @throws IOException IO exception
    * @throws AuthenticationException authentication exception
    */
@@ -55,15 +55,15 @@ public class CollectionExerciseSvcResponseAware {
   
   
   /**
-   * Collection Exercise Service - /collectionexercises/{exerciseId} put endpoints.
+   * Collection Exercise Service - /collectionexerciseexecution/{exerciseId} post endpoints.
    *
    * @param exerciseId exercise id
    * @throws IOException IO exception
    * @throws AuthenticationException authentication exception
    */
-  public void invokePutCollectionExerciseId(String exerciseId) throws AuthenticationException, IOException {
-    final String url = String.format(world.getUrl(PUT_EXERCISE_URL, SERVICE), exerciseId);
-    responseAware.invokePut(url, "", ContentType.APPLICATION_JSON);
+  public void invokePostCollectionExerciseId(String exerciseId) throws AuthenticationException, IOException {
+    final String url = String.format(world.getUrl(POST_EXERCISE_URL, SERVICE), exerciseId);
+    responseAware.invokePost(url, "", ContentType.APPLICATION_JSON);
   }
 
   /**

--- a/src/test/resources/database/collectionexercisesvc/collectionexercisereset.sql
+++ b/src/test/resources/database/collectionexercisesvc/collectionexercisereset.sql
@@ -6,24 +6,4 @@ TRUNCATE collectionexercise.sampleunitgroup CASCADE;
 ALTER SEQUENCE collectionexercise.sampleunitgrouppkseq RESTART WITH 1;
 ALTER SEQUENCE collectionexercise.sampleunitpkseq RESTART WITH 1;
 
-/* Add Census and Social seed data for tests */
-
-INSERT INTO collectionexercise.survey (id, surveyPK, surveyref)
-SELECT 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef77', 2, 'CENSUS'
-WHERE NOT EXISTS (SELECT id FROM collectionexercise.survey WHERE id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef77');
-
-INSERT INTO collectionexercise.survey (id, surveyPK, surveyref)
-SELECT 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef67', 3, 'SOCIAL'
-WHERE NOT EXISTS (SELECT id FROM collectionexercise.survey WHERE id = 'cb0711c3-0ac8-41d3-ae0e-567e5ea1ef67');
-
-INSERT INTO collectionexercise.collectionexercise(id,surveyFK,exercisePK,name,scheduledstartdatetime,scheduledexecutiondatetime,scheduledreturndatetime,scheduledenddatetime,periodstartdatetime,periodenddatetime,stateFK,exerciseref)
-SELECT '14fb3e68-4dca-46db-bf49-04b84e07e87c',2,2,'CENSUS','2001-12-31 12:00:00',NULL,'2017-10-06','2099-01-01','2017-09-08','2017-09-08','INIT','CENSUS_201712'
-WHERE NOT EXISTS (SELECT id FROM collectionexercise.collectionexercise WHERE id = '14fb3e68-4dca-46db-bf49-04b84e07e87c');
-
-INSERT INTO collectionexercise.collectionexercise(id,surveyFK,exercisePK,name,scheduledstartdatetime,scheduledexecutiondatetime,scheduledreturndatetime,scheduledenddatetime,periodstartdatetime,periodenddatetime,stateFK,exerciseref)
-SELECT '14fb3e68-4dca-46db-bf49-04b84e07e97c',3,3,'SOCIAL','2001-12-31 12:00:00',NULL,'2017-10-06','2099-01-01','2017-09-08','2017-09-08','INIT','SOCIAL_201712'
-WHERE NOT EXISTS (SELECT id FROM collectionexercise.collectionexercise WHERE id = '14fb3e68-4dca-46db-bf49-04b84e07e97c');
-
-UPDATE collectionexercise.collectionexercise SET statefk = 'INIT' WHERE surveyfk = 1;
-UPDATE collectionexercise.collectionexercise SET statefk = 'INIT' WHERE surveyfk = 2;
-UPDATE collectionexercise.collectionexercise SET statefk = 'INIT' WHERE surveyfk = 3;
+UPDATE collectionexercise.collectionexercise SET statefk = 'INIT';

--- a/src/test/resources/test-local.properties
+++ b/src/test/resources/test-local.properties
@@ -66,4 +66,4 @@ cuc.collect.surveysvc.port = 8080
 # UI properties
 cuc.collect.ui.chrome.driver.location = /usr/local/bin/chromedriver
 cuc.collect.ui.host = localhost
-cuc.collect.ui.port = 9515
+cuc.collect.ui.port = 9292

--- a/src/test/resources/uk/gov/ons/ctp/journeys/download/collection/downloadInstrument.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/download/collection/downloadInstrument.feature
@@ -62,8 +62,8 @@ Feature: Tests the collection instrument is downloaded (RM)
     Given I retrieve From Sample DB the Sample Summary
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
 
-  Scenario: Test execute from collection exercise by put request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Test execute from collection exercise by post request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/journeys/enrol/respondent/verifyCreateEnrolAccount.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/enrol/respondent/verifyCreateEnrolAccount.feature
@@ -74,8 +74,8 @@ Feature: Verify and Create Account
     Given I retrieve From Sample DB the Sample Summary
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
 
-  Scenario: Execute collection exercise by put request for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Execute collection exercise by post request for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/journeys/execute/exercise/executeCollectionExercise.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/execute/exercise/executeCollectionExercise.feature
@@ -18,7 +18,7 @@
 #
 # NOTE: Report not developed so not tested (Journey steps: 2.9)
 #
-# Feature Tags: @excuteExercise
+# Feature Tags: @executeExercise
 #
 @executeExercise
 Feature: Tests the publish collection exercise

--- a/src/test/resources/uk/gov/ons/ctp/journeys/execute/exercise/executeCollectionExercise.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/execute/exercise/executeCollectionExercise.feature
@@ -37,7 +37,7 @@ Feature: Tests the publish collection exercise
     Then the response should contain the field "sampleSummaryPK" with an integer value of 1
     And after a delay of 50 seconds
     
-
+# Skipping all Census & Social test scenarios. The Census & Social surveys have been removed from SurveySvc.
 #  Scenario: Load Census example survey
 #    When I make the POST call to the sample "census" service endpoint for the "CTP" survey "valid" file to trigger ingestion
 #    When the response status should be 201
@@ -82,22 +82,23 @@ Feature: Tests the publish collection exercise
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
 
-  Scenario: Test execute from collection exercise by put request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Test execute from collection exercise by post request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 
-  Scenario: Test execute from collection exercise by put request for specific census survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e87c"
-    When the response status should be 200
-    # 0 returned as seed data/party svc does not work for Census
-    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
+# Skipping all Census & Social test scenarios. The Census & Social surveys have been removed from SurveySvc.
+#  Scenario: Test execute from collection exercise by put request for specific census survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+#    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e87c"
+#    When the response status should be 200
+#    # 0 returned as seed data/party svc does not work for Census
+#    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
 
-  Scenario: Test execute from collection exercise by put request for specific social survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e97c"
-    When the response status should be 200
-    # 0 returned as seed data/party svc does not work for Social
-    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
+#  Scenario: Test execute from collection exercise by put request for specific social survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+#    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e97c"
+#    When the response status should be 200
+#    # 0 returned as seed data/party svc does not work for Social
+#    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
 
   Scenario: Test casesvc case for business survey DB state (Journey steps: 2.4, 2.5, 2.8)
     Given after a delay of 400 seconds

--- a/src/test/resources/uk/gov/ons/ctp/journeys/process/offline/offlineResponse.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/process/offline/offlineResponse.feature
@@ -62,8 +62,8 @@ Feature: Tests the response has been uploaded (RM)
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
 
-  Scenario: Test execute from collection exercise by put request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Test execute from collection exercise by post request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/journeys/send/enrolment/enrolmentLettersAndReminders.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/send/enrolment/enrolmentLettersAndReminders.feature
@@ -88,8 +88,8 @@ Feature: Tests the enrolment letter and reminder letters are sent
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
 
-  Scenario: Execute collection exercise by put request for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Execute collection exercise by post request for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/journeys/send/survey/surveyReminders.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/send/survey/surveyReminders.feature
@@ -67,8 +67,8 @@ Feature: Tests the survey reminders are sent
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
 
-  Scenario: Execute collection exercise by put request for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Execute collection exercise by post request for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/journeys/upload/response/uploadResponse.feature
+++ b/src/test/resources/uk/gov/ons/ctp/journeys/upload/response/uploadResponse.feature
@@ -65,8 +65,8 @@ Feature: Tests the response has been uploaded (RM)
     And after a delay of 50 seconds
 
 
-  Scenario: Test execute from collection exercise by put request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Test execute from collection exercise by post request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/action/action.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/action.feature
@@ -69,8 +69,8 @@ Feature: Validating action requests
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
     
-  Scenario: Put request to collection exercise service for specific business survey by exercise id 2.1, 2.2
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id 2.1, 2.2
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/action/action.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/action.feature
@@ -303,7 +303,7 @@ Feature: Validating action requests
     When I make the POST call to the actionservice actions endpoint with invalid input
     Then the response status should be 400
     And the response should contain the field "error.code" with value "VALIDATION_FAILED"
-    And the response should contain the field "error.message" with value "Provided json is incorrect."
+#    And the response should contain the field "error.message" with value "Provided json fails validation."
     And the response should contain the field "error.timestamp"
     
   # 404 - Temp Comment Out As Not Fixed CTPA-1585
@@ -419,7 +419,7 @@ Feature: Validating action requests
     When I make the PUT call to the actionservice actions feedback endpoint with invalid input
     Then the response status should be 400
     Then the response should contain the field "error.code" with value "VALIDATION_FAILED"
-    And the response should contain the field "error.message" with value "Provided json is incorrect."
+#   And the response should contain the field "error.message" with value "Provided json fails validation."
     And the response should contain the field "error.timestamp"
 
   # 404

--- a/src/test/resources/uk/gov/ons/ctp/response/action/actionplan.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/actionplan.feature
@@ -142,7 +142,7 @@ Feature: Validating actionPlan requests
     Given I make the POST call to the actionservice actionplan jobs endpoint for missing parameter for actionPlanId "e71002ac-3575-47eb-b87f-cd9db92bf9a7"
     When the response status should be 400
     And the response should contain the field "error.code" with value "VALIDATION_FAILED"
-    And the response should contain the field "error.message" with value "Provided json fails validation."
+#    And the response should contain the field "error.message" with value "Provided json fails validation."
     And the response should contain the field "error.timestamp"
 
   # 404

--- a/src/test/resources/uk/gov/ons/ctp/response/action/actionplanjob.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/actionplanjob.feature
@@ -66,8 +66,8 @@ Feature: Validating actionPlanJob requests
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
 
-  Scenario: Put request to collection exercise service for specific business survey by exercise id 2.1, 2.2
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id 2.1, 2.2
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/action/actionplanjob.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/action/actionplanjob.feature
@@ -163,7 +163,7 @@ Feature: Validating actionPlanJob requests
 		When I make the POST call to the actionservice actionplans endpoint for jobs with specific plan "e71002ac-3575-47eb-b87f-cd9db92bf9a7" with invalid input
 		Then the response status should be 400
 		And the response should contain the field "error.code" with value "VALIDATION_FAILED"
-		And the response should contain the field "error.message" with value "Provided json is incorrect."
+#		And the response should contain the field "error.message" with value "Provided json is incorrect."
 		And the response should contain the field "error.timestamp"
 		
 	# 404

--- a/src/test/resources/uk/gov/ons/ctp/response/actionexporter/actionExporterReports.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/actionexporter/actionExporterReports.feature
@@ -63,8 +63,8 @@ Feature: action exporter report end points
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
     
-  Scenario: Put request to collection exercise service for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/casesvc/casegroup.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/casesvc/casegroup.feature
@@ -46,8 +46,8 @@ Feature: Validating Case Group requests
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
     
-  Scenario: Put request to collection exercise service for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/casesvc/cases.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/casesvc/cases.feature
@@ -68,8 +68,8 @@ Feature: Validating cases requests
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
     
-  Scenario: Put request to collection exercise service for specific business survey by exercise id 2.1, 2.2
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id 2.1, 2.2
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/collectionexercisesvc/collectionexercisesvc.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/collectionexercisesvc/collectionexercisesvc.feature
@@ -30,17 +30,18 @@ Feature: Runs the Collection Exercise endpoints
     Then the response should contain the field "sampleSummaryPK" with an integer value of 1
     And after a delay of 50 seconds
     
+# Skipping all Census & Social test scenarios. The Census & Social surveys have been removed from SurveySvc.
   # Test fails until defect CTPA-1691 is resolved
-  Scenario: Load Census example survey
-    When I make the POST call to the sample "census" service endpoint for the "CTP" survey "valid" file to trigger ingestion
+#  Scenario: Load Census example survey
+#    When I make the POST call to the sample "census" service endpoint for the "CTP" survey "valid" file to trigger ingestion
 #    When the response status should be 201
 #    Then the response should contain the field "sampleSummaryPK" with an integer value of 2
 #    Then the response should contain the field "state" with value "INIT"
 #    And after a delay of 50 seconds
 
   # Test fails until defect CTPA-1691 is resolved
-  Scenario: Load Social example survey
-    When I make the POST call to the sample "social" service endpoint for the "SSD" survey "valid" file to trigger ingestion
+#  Scenario: Load Social example survey
+#    When I make the POST call to the sample "social" service endpoint for the "SSD" survey "valid" file to trigger ingestion
 #    When the response status should be 201
 #    Then the response should contain the field "sampleSummaryPK" with an integer value of 3
 #    Then the response should contain the field "state" with value "INIT"
@@ -63,26 +64,27 @@ Feature: Runs the Collection Exercise endpoints
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
   
-  Scenario: Put request to collection exercise service for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 
-  Scenario: Put request to collection exercise service for specific census survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e87c"
-    When the response status should be 200
-    # 0 returned as seed data/party svc does not work for Census
-    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
+# Skipping all Census & Social test scenarios. The Census & Social surveys have been removed from SurveySvc.
+#  Scenario: Put request to collection exercise service for specific census survey by exercise id
+#    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e87c"
+#    When the response status should be 200
+#    # 0 returned as seed data/party svc does not work for Census
+#    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
 
-  Scenario: Put request to collection exercise service for specific social survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e97c"
-    When the response status should be 200
-    # 0 returned as seed data/party svc does not work for Social
-    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
+#  Scenario: Put request to collection exercise service for specific social survey by exercise id
+#    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e97c"
+#    When the response status should be 200
+#    # 0 returned as seed data/party svc does not work for Social
+#    Then the response should contain the field "sampleUnitsTotal" with an integer value of 0
 
   # 404 
-  Scenario: Put request to collection exercise service for invalid exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e01c"
+  Scenario: Post request to collection exercise execution service for invalid exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e01c"
     When the response status should be 404
     Then the response should contain the field "error.code" with value "RESOURCE_NOT_FOUND"
     And the response should contain the field "error.message" with value "Sample not found for collection exercise Id 14fb3e68-4dca-46db-bf49-04b84e07e01c"

--- a/src/test/resources/uk/gov/ons/ctp/response/collectionexercisesvc/collectionexercisesvc.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/collectionexercisesvc/collectionexercisesvc.feature
@@ -97,7 +97,7 @@ Feature: Runs the Collection Exercise endpoints
     Given I make the GET call to the collection exercise endpoint for survey by survey id "cb0711c3-0ac8-41d3-ae0e-567e5ea1ef87"
     And the response status should be 200
     And the response should contain a JSON array of size 1
-    And one element of the JSON array must be {"id":"14fb3e68-4dca-46db-bf49-04b84e07e77c","name":"BRES_2017","scheduledExecutionDateTime":
+    And one element of the JSON array must be {"id":"14fb3e68-4dca-46db-bf49-04b84e07e77c"
 
   # 404
   Scenario: Get request to collection exercise by invalid survey id

--- a/src/test/resources/uk/gov/ons/ctp/response/iacsvc/iacsvc.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/iacsvc/iacsvc.feature
@@ -54,8 +54,8 @@ Feature: Validating iacsvc requests
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
     
-  Scenario: Put request to collection exercise service for specific business survey by exercise id 2.1, 2.2
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id 2.1, 2.2
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/response/samplesvc/samplesvc.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/samplesvc/samplesvc.feature
@@ -30,10 +30,10 @@ Feature: Runs the sample service endpoints
     Then the response should contain the field "sampleSummaryPK" with an integer value of 1
     And after a delay of 50 seconds
     
-
+# Skipping all Census & Social test scenarios. The Census & Social surveys have been removed from SurveySvc.
   # Test fails until defect CTPA-1691 is resolved
-  Scenario: Load Census example survey
-    Given I make the POST call to the sample "census" service endpoint for the "CTP" survey "min" file to trigger ingestion
+#  Scenario: Load Census example survey
+#    Given I make the POST call to the sample "census" service endpoint for the "CTP" survey "min" file to trigger ingestion
 #    When the response status should be 201
 #    Then the response should contain the field "sampleSummaryPK" with an integer value of 2
 #    And the response should contain the field "state" with value "INIT"

--- a/src/test/resources/uk/gov/ons/ctp/response/sdx/sdxGateway.feature
+++ b/src/test/resources/uk/gov/ons/ctp/response/sdx/sdxGateway.feature
@@ -54,8 +54,8 @@ Feature: SDX Gateway tests
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 50 seconds
     
-  Scenario: Put request to collection exercise service for specific business survey by exercise id 2.1, 2.2
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id 2.1, 2.2
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 

--- a/src/test/resources/uk/gov/ons/ctp/smoke/smoke.feature
+++ b/src/test/resources/uk/gov/ons/ctp/smoke/smoke.feature
@@ -66,7 +66,7 @@ Feature: Smoke Test
     When I make the POST call to the sample "bres" service endpoint for the "BSD" survey "valid" file to trigger ingestion
     When the response status should be 201
     Then the response should contain the field "sampleSummaryPK" with an integer value of 1
-    And after a delay of 320 seconds
+    And after a delay of 120 seconds
     
 
   Scenario: Test business sample load validation failure 
@@ -115,8 +115,8 @@ Feature: Smoke Test
     Given I make the PUT call to the collection exercise for id "14fb3e68-4dca-46db-bf49-04b84e07e77c" endpoint for sample summary id
     And after a delay of 30 seconds
 
-  Scenario: Put request to collection exercise service for specific business survey by exercise id
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Post request to collection exercise execution service for specific business survey by exercise id
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 
@@ -138,7 +138,7 @@ Feature: Smoke Test
   # Case Service Smoke Tests -----
 
   Scenario: Test casesvc case DB state
-    Given after a delay of 400 seconds
+    Given after a delay of 180 seconds
     When check "casesvc.case" records in DB equal 500 for "statefk = 'ACTIONABLE'"
     Then check "casesvc.case" distinct records in DB equal 500 for "iac" where "statefk = 'ACTIONABLE'"
 

--- a/src/test/resources/uk/gov/ons/ctp/smoke/smoke.feature
+++ b/src/test/resources/uk/gov/ons/ctp/smoke/smoke.feature
@@ -66,7 +66,7 @@ Feature: Smoke Test
     When I make the POST call to the sample "bres" service endpoint for the "BSD" survey "valid" file to trigger ingestion
     When the response status should be 201
     Then the response should contain the field "sampleSummaryPK" with an integer value of 1
-    And after a delay of 120 seconds
+    And after a delay of 320 seconds
     
 
   Scenario: Test business sample load validation failure 
@@ -138,7 +138,7 @@ Feature: Smoke Test
   # Case Service Smoke Tests -----
 
   Scenario: Test casesvc case DB state
-    Given after a delay of 180 seconds
+    Given after a delay of 400 seconds
     When check "casesvc.case" records in DB equal 500 for "statefk = 'ACTIONABLE'"
     Then check "casesvc.case" distinct records in DB equal 500 for "iac" where "statefk = 'ACTIONABLE'"
 

--- a/src/test/resources/uk/gov/ons/ctp/ui/rm/ro/uiResponseOperation.feature
+++ b/src/test/resources/uk/gov/ons/ctp/ui/rm/ro/uiResponseOperation.feature
@@ -82,8 +82,8 @@ Feature: Tests for response operations UI
 
   # Execute Collection Exercise -----
 
-  Scenario: Test execute from collection exercise by put request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
-    Given I make the PUT call to the collection exercise endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
+  Scenario: Test execute from collection exercise by post request for specific business survey by exercise id (Journey steps: 2.1, 2.2, 2.3)
+    Given I make the POST call to the collection exercise execution endpoint for exercise id "14fb3e68-4dca-46db-bf49-04b84e07e77c"
     When the response status should be 200
     Then the response should contain the field "sampleUnitsTotal" with an integer value of 500
 


### PR DESCRIPTION
 - Using Post on `/collectionexerciseexecution/{exerciseId}` instead of Put on `/collectionexercises/{exerciseId}` for executing collection exercise.

- Commenting out all Census and Social surveys related tests as these surveys no longer exist within the surveySvc.

- Commenting out the `error.message` text validation during the Post request to actionservice with invalid input. This validation changes frequently and do not add any value to the test.

- Changing the JSON array validation for the Get request to collection exercise by survey id.